### PR TITLE
Replace committers with co-authors

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,9 @@ Git Switch adds a post commit hook to the git repositories you specify.
 
 You select the users to add to your pair/mob, and commit changes to your code.
 
-With each commit, the git-switch commit hook amends the commit to designate the author separate from the committer(s).
+With each commit, the git-switch commit hook amends the commit to designate the author separate from the co-author(s).
 
 Once each commit is complete, git-switch will automatically rotate users in your pair/mob, so the next user will be the author on the next commit.
-
-Add the following `git` alias to display commit history with author and committer(s) using `git lg`. [More on git aliases.](https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases)
-```
-lg = log --color --graph --abbrev-commit --pretty=format:'%C(cyan)%h%C(reset) -%C(magenta)%d%C(reset) %s %C(yellow)(%cr) %C(bold blue)<%an> (%cn)%C(reset)'
-```
 
 ## Development
 To run git-switch from source, run the following command:

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "babel-preset-stage-0": "6.22.0",
     "electron-compile": "6.4.2",
     "electron-squirrel-startup": "1.0.0",
+    "lodash.capitalize": "4.2.1",
     "md5": "2.2.1",
     "menubar": "5.2.1",
     "uuid": "3.1.0"

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "html-webpack-plugin": "2.29.0",
     "husky": "0.14.3",
     "lodash": "4.6.0",
-    "mocha": "3.4.2",
+    "mocha": "5.2.0",
     "normalize.css": "5.0.0",
     "postcss-cssnext": "2.9.0",
     "postcss-import": "9.1.0",

--- a/src/client/menu/users/index.js
+++ b/src/client/menu/users/index.js
@@ -47,7 +47,7 @@ export default class Users extends React.Component {
   renderUser = (user, index) => {
     const photoUrl = `https://www.gravatar.com/avatar/${md5(user.email.trim().toLowerCase())}?d=mm&s=28`
     const role = user.active
-      ? index === 0 ? 'Author' : 'Committer'
+      ? index === 0 ? 'Author' : 'Co-Author'
       : ''
 
     return (

--- a/src/common/services/__specs__/user.spec.js
+++ b/src/common/services/__specs__/user.spec.js
@@ -28,13 +28,13 @@ describe('services/user', () => {
 
     sinon.stub(configUtil, 'read').callsFake(() => config)
     sinon.stub(configUtil, 'write')
-    sinon.stub(gitService, 'updateAuthorAndCommitter')
+    sinon.stub(gitService, 'updateAuthorAndCoAuthors')
   })
 
   afterEach(() => {
     configUtil.read.restore()
     configUtil.write.restore()
-    gitService.updateAuthorAndCommitter.restore()
+    gitService.updateAuthorAndCoAuthors.restore()
   })
 
   describe('#get', () => {
@@ -67,7 +67,7 @@ describe('services/user', () => {
       expect(addedUser.email).to.eql(userToAdd.email)
       expect(addedUser.id).to.not.be.null
       expect(configUtil.write).to.have.been.calledWith(expected)
-      expect(gitService.updateAuthorAndCommitter).to.have.been.calledWith(actual)
+      expect(gitService.updateAuthorAndCoAuthors).to.have.been.calledWith(actual)
     })
   })
 
@@ -88,7 +88,7 @@ describe('services/user', () => {
 
       expect(actual).to.eql(expected.users)
       expect(configUtil.write).to.have.been.calledWith(expected)
-      expect(gitService.updateAuthorAndCommitter).to.have.been.calledWith(actual)
+      expect(gitService.updateAuthorAndCoAuthors).to.have.been.calledWith(actual)
     })
 
     describe('when updated user does not already exist', () => {
@@ -121,7 +121,7 @@ describe('services/user', () => {
 
       expect(actual).to.eql(expected)
       expect(configUtil.write).to.have.been.calledWith(newConfig)
-      expect(gitService.updateAuthorAndCommitter).to.have.been.calledWith(actual)
+      expect(gitService.updateAuthorAndCoAuthors).to.have.been.calledWith(actual)
     })
   })
 
@@ -132,7 +132,7 @@ describe('services/user', () => {
 
         expect(actual).to.eql(users)
         expect(configUtil.write).to.not.have.been.called
-        expect(gitService.updateAuthorAndCommitter).to.not.have.been.called
+        expect(gitService.updateAuthorAndCoAuthors).to.not.have.been.called
       })
     })
 
@@ -148,7 +148,7 @@ describe('services/user', () => {
 
         expect(actual).to.eql(users)
         expect(configUtil.write).to.not.have.been.called
-        expect(gitService.updateAuthorAndCommitter).to.not.have.been.called
+        expect(gitService.updateAuthorAndCoAuthors).to.not.have.been.called
       })
     })
 
@@ -175,7 +175,7 @@ describe('services/user', () => {
 
         expect(actual).to.eql(expected.users)
         expect(configUtil.write).to.have.been.calledWith(expected)
-        expect(gitService.updateAuthorAndCommitter).to.have.been.calledWith(expected.users)
+        expect(gitService.updateAuthorAndCoAuthors).to.have.been.calledWith(expected.users)
       })
     })
 
@@ -208,7 +208,7 @@ describe('services/user', () => {
 
         expect(actual).to.eql(expected.users)
         expect(configUtil.write).to.have.been.calledWith(expected)
-        expect(gitService.updateAuthorAndCommitter).to.have.been.calledWith(expected.users)
+        expect(gitService.updateAuthorAndCoAuthors).to.have.been.calledWith(expected.users)
       })
     })
   })
@@ -242,7 +242,7 @@ describe('services/user', () => {
 
       expect(actual).to.eql(expected.users)
       expect(configUtil.write).to.have.been.calledWith(expected)
-      expect(gitService.updateAuthorAndCommitter).to.have.been.calledWith(expected.users)
+      expect(gitService.updateAuthorAndCoAuthors).to.have.been.calledWith(expected.users)
     })
 
     describe('when user does not exist', () => {

--- a/src/common/services/notification.js
+++ b/src/common/services/notification.js
@@ -1,5 +1,5 @@
 import { Notification } from 'electron'
-import { formatActiveUserFirstNames, getCommiterLabel } from '../utils/string'
+import { formatActiveUserFirstNames, getNotificationLabel } from '../utils/string'
 import * as userService from './user'
 
 function showNotification(config) {
@@ -7,12 +7,12 @@ function showNotification(config) {
   notification.show()
 }
 
-export function showCurrentCommiters(options = {}) {
+export function showCurrentAuthors(options = {}) {
   const users = userService.get()
   const activeUserCount = users.filter(u => u.active).length
 
   showNotification({
-    title: options.title || `Current ${getCommiterLabel(activeUserCount)}:`,
+    title: options.title || `Current ${getNotificationLabel(activeUserCount)}:`,
     sound: 'Purr',
     body: formatActiveUserFirstNames(users)
   })

--- a/src/common/services/user.js
+++ b/src/common/services/user.js
@@ -19,7 +19,7 @@ export function add({ name, email, rsaKeyPath }) {
   users.push({ id, name, email, rsaKeyPath, active: true })
 
   const updated = persist(users)
-  gitService.updateAuthorAndCommitter(users)
+  gitService.updateAuthorAndCoAuthors(users)
 
   return updated
 }
@@ -34,7 +34,7 @@ export function update(user) {
   }
 
   const updated = persist(users)
-  gitService.updateAuthorAndCommitter(users)
+  gitService.updateAuthorAndCoAuthors(users)
   return updated
 }
 
@@ -46,7 +46,7 @@ export function remove(id) {
   users.splice(foundIndex, 1)
 
   const updated = persist(users)
-  gitService.updateAuthorAndCommitter(users)
+  gitService.updateAuthorAndCoAuthors(users)
   return updated
 }
 
@@ -63,7 +63,7 @@ export function rotate() {
   ]
 
   const updated = persist(updatedUsers)
-  gitService.updateAuthorAndCommitter(updatedUsers)
+  gitService.updateAuthorAndCoAuthors(updatedUsers)
   return updated
 }
 
@@ -82,6 +82,6 @@ export function toggleActive(id) {
     ...inactiveUsers
   ]
   const persisted = persist(updatedUsers)
-  gitService.updateAuthorAndCommitter(updatedUsers)
+  gitService.updateAuthorAndCoAuthors(updatedUsers)
   return persisted
 }

--- a/src/common/utils/__specs__/string.spec.js
+++ b/src/common/utils/__specs__/string.spec.js
@@ -23,21 +23,21 @@ describe('utils/string', () => {
     })
   })
 
-  describe('#getCommiterLabel', () => {
-    it('returns "commiter" if userCount is 1', async () => {
-      expect(subject.getCommiterLabel(1)).to.eql('commiter')
+  describe('#getNotificationLabel', () => {
+    it('returns "author" if userCount is 1', async () => {
+      expect(subject.getNotificationLabel(1)).to.eql('author')
     })
 
     it('returns "pair" if userCount is 2', async () => {
-      expect(subject.getCommiterLabel(2)).to.eql('pair')
+      expect(subject.getNotificationLabel(2)).to.eql('pair')
     })
 
     it('returns "mob" if userCount is > 2', async () => {
-      expect(subject.getCommiterLabel(3)).to.eql('mob')
+      expect(subject.getNotificationLabel(3)).to.eql('mob')
     })
 
-    it('capitalizes if capitalize is true', async () => {
-      expect(subject.getCommiterLabel(4, true)).to.eql('Mob')
+    it('capitalizes if shouldCapitalize is true', async () => {
+      expect(subject.getNotificationLabel(4, true)).to.eql('Mob')
     })
   })
 })

--- a/src/common/utils/string.js
+++ b/src/common/utils/string.js
@@ -1,3 +1,5 @@
+import capitalize from 'lodash/capitalize'
+
 export function formatActiveUserFirstNames(users) {
   const activeUserFirstNames = users.filter(u => u.active).map(u => u.name.split(' ')[0])
 
@@ -10,8 +12,4 @@ export function getNotificationLabel(userCount, shouldCapitalize = false) {
   const label = userCount < 2 ? 'author' : (userCount === 2 ? 'pair' : 'mob')
 
   return shouldCapitalize ? capitalize(label) : label
-}
-
-function capitalize(str) {
-  return str.slice(0, 1).toUpperCase() + str.slice(1)
 }

--- a/src/common/utils/string.js
+++ b/src/common/utils/string.js
@@ -6,10 +6,10 @@ export function formatActiveUserFirstNames(users) {
     : `${activeUserFirstNames.slice(0, -1).join(', ')} and ${activeUserFirstNames.slice(-1)}`
 }
 
-export function getCommiterLabel(userCount, capitalizeIt = false) {
-  const label = userCount < 2 ? 'commiter' : (userCount === 2 ? 'pair' : 'mob')
+export function getNotificationLabel(userCount, shouldCapitalize = false) {
+  const label = userCount < 2 ? 'author' : (userCount === 2 ? 'pair' : 'mob')
 
-  return capitalizeIt ? capitalize(label) : label
+  return shouldCapitalize ? capitalize(label) : label
 }
 
 function capitalize(str) {

--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,7 @@ import path from 'path'
 import CHANNELS from './common/ipc-channels'
 import * as notificationService from './common/services/notification'
 import * as userService from './common/services/user'
-import { getCommiterLabel } from './common/utils/string'
+import { getNotificationLabel } from './common/utils/string'
 import install from './common/utils/install'
 import IpcRouter from './ipc-router'
 
@@ -21,15 +21,15 @@ const mb = menubar({
   height: 600
 })
 
-const appExecutablePath = mb.app.getPath('exe')
-install(process.platform, appExecutablePath)
-
 const isSecondInstance = mb.app.makeSingleInstance(processAppArgs)
 if (isSecondInstance) {
   mb.app.exit()
 } else {
   processAppArgs(process.argv)
 }
+
+const appExecutablePath = mb.app.getPath('exe')
+install(process.platform, appExecutablePath)
 
 mb.on('ready', handleAppReady)
 mb.on('after-create-window', handleAfterCreateWindow)
@@ -43,7 +43,7 @@ function handleAppReady() {
     rotateUsers()
     state.rotateOnOpen = false
   } else if (!isDev) {
-    notificationService.showCurrentCommiters()
+    notificationService.showCurrentAuthors()
   }
 }
 
@@ -68,8 +68,8 @@ function rotateUsers() {
   const updatedUsers = userService.rotate()
   const activeUserCount = updatedUsers.filter(u => u.active).length
   if (activeUserCount > 1) {
-    const label = getCommiterLabel(activeUserCount, true)
-    notificationService.showCurrentCommiters({ title: `${label} rotated to:` })
+    const label = getNotificationLabel(activeUserCount, true)
+    notificationService.showCurrentAuthors({ title: `${label} rotated to:` })
     mb.window.webContents.send(CHANNELS.USERS_UPDATED, updatedUsers)
   }
 }


### PR DESCRIPTION
Append `Co-Authored-By` to commits when more than one user is selected.
This means git-switch co-authors will only work with repos on github
but it will be more stable than committers which are often over-written
when rebasing and other inconsistencies.