### PR TITLE
Add ssh host management to user add/edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Cross-platform electron app for managing git users while pair/mob programming
 
+
 ## Installation
 
 * You will find deployables for each of the 3 major platforms [here](https://github.com/pluralsight/git-switch-electron/releases).
@@ -10,7 +11,9 @@ Cross-platform electron app for managing git users while pair/mob programming
 * Add your git repos and pair/mob users.
 * Enjoy!
 
+
 ## How it works
+
 
 ### Co-Authors
 
@@ -22,14 +25,15 @@ With each commit, the git-switch commit hook amends the commit to designate the 
 
 Once each commit is complete, git-switch will automatically rotate users in your pair/mob, so the next user will be the author on the next commit.
 
+
 ### Identities
 
-Git Switch will modify your ssh config (`~\.ssh\config`) to specify the current author's identity file.
+Git Switch will modify your ssh config (`~/.ssh/config`) to specify the current author's identity file (RSA key).
 
 By default, it does this for the `github.com` host.
 
-If you use a different host for your repository, you can add a `host` property to the config object at `~\.git-switch\config.json`.
-This cannot currently be managed through the UI, but will persist if you make other changes through the UI.
+If you use a different host for your repository, you can provide the `SSH Host` value, in the add/edit user form, that your identity file was issued for.
+
 
 ## CLI usage
 
@@ -63,6 +67,7 @@ git-switch
 
 Running `-h` or `--help` on any command/sub-command will provide usage information
 
+
 ## Development
 
 To run git-switch from source, run the following command:
@@ -75,6 +80,7 @@ To launch the electron app with the chrome dev tools open by default, simply run
 ```
 npm run start:dev
 ```
+
 
 ## Publishing a release
 

--- a/src/cli/commands/users-commands/add.js
+++ b/src/cli/commands/users-commands/add.js
@@ -25,16 +25,28 @@ export const builder = (yargs) =>
         describe: 'The path to the user\'s rsa key',
         string: true,
         default: ''
+      },
+      host: {
+        alias: 'H',
+        describe: 'The host the rsa key is issued to',
+        string: true
       }
     })
     .version(false)
 
 export const handler = (args) => {
-  const { name, email, key: rsaKeyPath, doWork, verbose } = args
+  const { doWork, verbose } = args
 
   let updatedUsers
   if (doWork) {
-    updatedUsers = userService.add({ name, email, rsaKeyPath })
+    const { name, email, key: rsaKeyPath, host } = args
+
+    const userToAdd = { name, email, rsaKeyPath }
+    if (host) {
+      userToAdd.sshHost = host
+    }
+
+    updatedUsers = userService.add(userToAdd)
   } else {
     updatedUsers = userService.get()
   }

--- a/src/cli/commands/users-commands/edit.js
+++ b/src/cli/commands/users-commands/edit.js
@@ -27,30 +27,41 @@ export const builder = (yargs) =>
         alias: 'k',
         describe: 'The path to the user\'s rsa key',
         string: true
+      },
+      host: {
+        alias: 'H',
+        describe: 'The host the rsa key is issued to',
+        string: true
       }
     })
     .version(false)
 
 export const handler = (args) => {
-  const { userId, name, email, key, doWork, verbose } = args
+  const { doWork, verbose } = args
   const users = userService.get()
 
   let updatedUsers
   if (doWork) {
+    const { userId, name, email, key, host } = args
+
     const user = users.find((u) => u.id === userId)
     if (!user) {
       logger.error('User not found')
       return
     }
 
-    const rsaKeyPath = key == null ? user.rsaKeyPath : key
-
-    updatedUsers = userService.update({
+    const updatedUser = {
       ...user,
       name: name || user.name,
       email: email || user.email,
-      rsaKeyPath
-    })
+      rsaKeyPath: key == null ? user.rsaKeyPath : key,
+      sshHost: host == null ? user.sshHost : host
+    }
+    if (updatedUser.sshHost && !updatedUser.rsaKeyPath) {
+      delete updatedUser.sshHost
+    }
+
+    updatedUsers = userService.update(updatedUser)
   } else {
     updatedUsers = users
   }

--- a/src/cli/commands/users-commands/list.js
+++ b/src/cli/commands/users-commands/list.js
@@ -18,7 +18,7 @@ export const builder = (yargs) =>
     .version(false)
 
 const getUserLines = (columns) => {
-  const [id, name, email, rsaKeyPath, active] = columns
+  const [id, name, email, rsaKeyPath, sshHost, active] = columns
   const rows = id.values.length
 
   return Array(rows).fill(null).map((_, i) =>
@@ -27,6 +27,7 @@ ${getField({ value: id.values[i], minWidth: id.width })} | \
 ${getField({ value: name.values[i], minWidth: name.width })} | \
 ${getField({ value: email.values[i], minWidth: email.width })} | \
 ${getField({ value: rsaKeyPath.values[i], minWidth: rsaKeyPath.width })} | \
+${getField({ value: sshHost.values[i], minWidth: sshHost.width })} | \
 ${getField({ value: active.values[i] ? '✓' : '', minWidth: active.width, startWidth: 5 })} |`)
 }
 
@@ -45,6 +46,7 @@ export const handler = (args) => {
     getColumn({ data: users, header: 'Name', key: 'name' }),
     getColumn({ data: users, header: 'Email', key: 'email' }),
     getColumn({ data: users, header: 'RSA Key', key: 'rsaKeyPath' }),
+    getColumn({ data: users, header: 'SSH Host', key: 'sshHost' }),
     getColumn({ data: users, header: 'Is Active', key: 'active' })
   ]
   const lines = [

--- a/src/cli/utils/list-helper.js
+++ b/src/cli/utils/list-helper.js
@@ -15,8 +15,8 @@ export const getField = (overrides) => {
     minWidth: 0,
     paddingChar: ' ',
     startWidth: 0,
-    value: '',
-    ...overrides
+    ...overrides,
+    value: overrides.value || ''
   }
 
   return value.padStart(startWidth, paddingChar).padEnd(minWidth, paddingChar)

--- a/src/client/menu/components/user-form/index.js
+++ b/src/client/menu/components/user-form/index.js
@@ -91,6 +91,17 @@ export function UserForm(props) {
             Browse
           </Button>
         </div>
+        {
+          user.rsaKeyPath && (
+            <input
+              id="sshHost"
+              className={css.field}
+              value={user.sshHost}
+              placeholder="SSH Host (github.com)"
+              onChange={handleFieldChange}
+            />
+          )
+        }
       </div>
       <div className={css.buttonSection}>
         <Button onClick={handleCancel}>Cancel</Button>

--- a/src/common/services/__specs__/user.spec.js
+++ b/src/common/services/__specs__/user.spec.js
@@ -20,6 +20,7 @@ describe('services/user', () => {
       name: 'Second User',
       email: 'second@email.com',
       rsaKeyPath: '/not/a/real/path',
+      sshHost: 'not.github.com',
       active: false
     }]
     config = { users }
@@ -68,7 +69,8 @@ describe('services/user', () => {
       userToAdd = {
         name: 'New User',
         email: 'new@email.com',
-        rsaKeyPath: '/a/path/to/nowhere'
+        rsaKeyPath: '/a/path/to/nowhere',
+        sshHost: 'not.github.com'
       }
 
       users = [
@@ -96,9 +98,10 @@ describe('services/user', () => {
 
     it('updates git authors and rsa keys', () => {
       const updatedUsers = subject.add(userToAdd)
+      const { rsaKeyPath, sshHost } = updatedUsers[0]
 
       expect(gitService.updateAuthorAndCoAuthors).to.have.been.calledWith(updatedUsers)
-      expect(sshService.rotateIdentityFile).to.have.been.calledWith(updatedUsers[0].rsaKeyPath)
+      expect(sshService.rotateIdentityFile).to.have.been.calledWith(rsaKeyPath, sshHost)
     })
   })
 
@@ -128,9 +131,10 @@ describe('services/user', () => {
 
     it('updates git authors and rsa keys', () => {
       const updatedUsers = subject.update(userToUpdate)
+      const { rsaKeyPath, sshHost } = updatedUsers[0]
 
       expect(gitService.updateAuthorAndCoAuthors).to.have.been.calledWith(updatedUsers)
-      expect(sshService.rotateIdentityFile).to.have.been.calledWith(updatedUsers[0].rsaKeyPath)
+      expect(sshService.rotateIdentityFile).to.have.been.calledWith(rsaKeyPath, sshHost)
     })
 
     describe('when updated user does not already exist', () => {
@@ -167,9 +171,10 @@ describe('services/user', () => {
 
     it('updates git authors and rsa keys', () => {
       const updatedUsers = subject.remove([users[0].id])
+      const { rsaKeyPath, sshHost } = updatedUsers[0]
 
       expect(gitService.updateAuthorAndCoAuthors).to.have.been.calledWith(updatedUsers)
-      expect(sshService.rotateIdentityFile).to.have.been.calledWith(updatedUsers[0].rsaKeyPath)
+      expect(sshService.rotateIdentityFile).to.have.been.calledWith(rsaKeyPath, sshHost)
     })
 
     it('allows removing by name', () => {
@@ -252,7 +257,7 @@ describe('services/user', () => {
         subject.rotate()
 
         expect(gitService.updateAuthorAndCoAuthors).to.have.been.calledWith(expected.users)
-        expect(sshService.rotateIdentityFile).to.have.been.calledWith(users[1].rsaKeyPath)
+        expect(sshService.rotateIdentityFile).to.have.been.calledWith(users[1].rsaKeyPath, users[1].sshHost)
       })
     })
 
@@ -295,7 +300,7 @@ describe('services/user', () => {
         subject.rotate()
 
         expect(gitService.updateAuthorAndCoAuthors).to.have.been.calledWith(expected.users)
-        expect(sshService.rotateIdentityFile).to.have.been.calledWith(users[1].rsaKeyPath)
+        expect(sshService.rotateIdentityFile).to.have.been.calledWith(users[1].rsaKeyPath, users[1].sshHost)
       })
     })
   })
@@ -344,7 +349,7 @@ describe('services/user', () => {
       subject.toggleActive([users[2].id, users[3].id])
 
       expect(gitService.updateAuthorAndCoAuthors).to.have.been.calledWith(expected.users)
-      expect(sshService.rotateIdentityFile).to.have.been.calledWith(users[0].rsaKeyPath)
+      expect(sshService.rotateIdentityFile).to.have.been.calledWith(users[0].rsaKeyPath, users[0].sshHost)
     })
 
     it('allows toggling by name', () => {

--- a/src/common/services/ssh.js
+++ b/src/common/services/ssh.js
@@ -2,14 +2,8 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 
-import { config } from '../utils'
-
 export const SSH_CONFIG_PATH = path.join(os.homedir(), '.ssh', 'config')
 const DEFAULT_HOST = 'github.com'
-
-function getHost() {
-  return config.read().host || DEFAULT_HOST
-}
 
 function getRegex(host) {
   const escapedHost = host.replace('.', '\\.')
@@ -26,12 +20,12 @@ function writeToSshConfig(contents) {
   fs.writeFileSync(SSH_CONFIG_PATH, contents, { encoding: 'utf-8', mode: 0o644 })
 }
 
-export function rotateIdentityFile(identityFile) {
+export function rotateIdentityFile(identityFile, host) {
   if (!identityFile) {
     return
   }
 
-  const host = getHost()
+  host = host || DEFAULT_HOST
   const rsaConfig = getRsaConfig(host, identityFile)
 
   if (!fs.existsSync(SSH_CONFIG_PATH)) {

--- a/src/common/services/user.js
+++ b/src/common/services/user.js
@@ -13,7 +13,7 @@ const persist = (users) => {
 
 const updateExternalServices = (users) => {
   gitService.updateAuthorAndCoAuthors(users)
-  sshService.rotateIdentityFile(users[0].rsaKeyPath)
+  sshService.rotateIdentityFile(users[0].rsaKeyPath, users[0].sshHost)
 }
 
 export const generateId = () => {

--- a/src/common/utils/__specs__/string.spec.js
+++ b/src/common/utils/__specs__/string.spec.js
@@ -47,5 +47,10 @@ describe('utils/string', () => {
       const strings = ['short', 'thisislong', 'thisisreallylong']
       expect(subject.getLongestString(strings)).to.equal(16)
     })
+
+    it('returns 0 for undefined', () => {
+      const strings = [undefined]
+      expect(subject.getLongestString(strings)).to.equal(0)
+    })
   })
 })

--- a/src/common/utils/string.js
+++ b/src/common/utils/string.js
@@ -16,7 +16,7 @@ export const getNotificationLabel = (activeUserCount, shouldCapitalize = false) 
 
 export const getLongestString = (strings) => {
   return strings.reduce((longest, string) => {
-    if (string.length > longest) {
+    if (string && string.length > longest) {
       longest = string.length
     }
 


### PR DESCRIPTION
- SSH host defaults to github.com and is overridden by the host
  associated with a selected RSA key
- User form field is enabled once a key path has been entered/selected
- Can also be managed via CLI