### PR TITLE
Fix husky compatibility

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,7 +27,15 @@
     ],
     "lines-between-class-members": "off",
     "mocha/no-exclusive-tests": "error",
-    "no-console": "error",
+    "no-console": [
+      "error",
+      {
+        "allow": [
+          "info",
+          "error"
+        ]
+      }
+    ],
     "no-new": "off",
     "no-unused-vars": [
       2,

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,10 +21,10 @@ jobs:
     name: Build git-collab
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 12.x
+          node-version: lts/*
       - name: Install node modules
         run: yarn
       - name: Lint

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -fy wine64
+          [ -z "$(which wine64)" ] && sudo ln -s $(which wine) $(which wine)64
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,7 @@ jobs:
     steps:
       - name: Create release
         id: create_release
+        # deprecated
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -23,10 +24,10 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -fy wine64
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 12.x
+          node-version: lts/*
       - name: Build app
         shell: bash
         run: |
@@ -37,6 +38,7 @@ jobs:
       - name: Zip packages
         run: yarn packages:zip
       - name: Upload macos
+        # deprecated
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -46,6 +48,7 @@ jobs:
           asset_name: git-collab-macos.zip
           asset_content_type: application/zip
       - name: Upload linux
+        # deprecated
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -55,6 +58,7 @@ jobs:
           asset_name: git-collab-linux.zip
           asset_content_type: application/zip
       - name: Upload windows
+        # deprecated
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "yarn build:clean && yarn build:compile",
     "build:clean": "rimraf ./dist",
-    "build:compile": "webpack",
+    "build:compile": "NODE_OPTIONS=--openssl-legacy-provider webpack",
     "lint": "yarn lint:main && yarn lint:renderer && yarn lint:cli",
     "lint:cli": "eslint ./src/cli",
     "lint:main": "eslint ./src/common",

--- a/scripts/package-zipper.js
+++ b/scripts/package-zipper.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-console */
-
 const archiver = require('archiver')
 const fs = require('fs')
 const path = require('path')
@@ -46,7 +44,7 @@ function removePackageSrc(targetOS) {
 }
 
 function zipPackage(targetOS) {
-  console.log(`Creating zip for '${targetOS}'...\n`)
+  console.info(`Creating zip for '${targetOS}'...\n`)
 
   const zippedDir = getPackageZipDir(targetOS)
   const sourceDir = getPackageSrcDir(targetOS)
@@ -68,9 +66,9 @@ function zipPackage(targetOS) {
 
     zipFile.on('close', () => {
       const size = getFileSizeString(archive.pointer())
-      console.log(`Created ${PACKAGE_BASE_NAME}-${targetOS}.zip (${size})`)
+      console.info(`Created ${PACKAGE_BASE_NAME}-${targetOS}.zip (${size})`)
 
-      console.log(`Removing unzipped build: ${sourceDir}...\n`)
+      console.info(`Removing unzipped build: ${sourceDir}...\n`)
       removePackageSrc(targetOS)
 
       resolve()
@@ -79,9 +77,9 @@ function zipPackage(targetOS) {
 }
 
 async function execute() {
-  console.log('Starting zip of all OS packages...\n')
+  console.info('Starting zip of all OS packages...\n')
   await Promise.all(Object.values(OS_NAMES).map(zipPackage))
-  console.log('Finished')
+  console.info('Finished')
 }
 
 execute()

--- a/src/common/services/git.js
+++ b/src/common/services/git.js
@@ -6,7 +6,8 @@ import { execute, logger } from '../utils'
 
 export const GIT_COLLAB_PATH = path.join(os.homedir(), '.git-collab')
 export const GIT_SWITCH_POST_COMMIT_BASE = '#!/bin/bash\n\n/bin/bash "$(dirname $0)"/post-commit.git-switch'
-export const POST_COMMIT_BASE = '#!/bin/bash\n\n/bin/bash "$(dirname $0)"/post-commit.git-collab'
+export const POST_COMMIT_BASE_OLD = '#!/bin/bash\n\n/bin/bash "$(dirname $0)"/post-commit.git-collab'
+export const POST_COMMIT_BASE = '#!/usr/bin/env sh\n\n[ -f "$(dirname $0)/git-collab/post-commit" ] && . $(dirname $0)/git-collab/post-commit'
 
 export const setAuthor = (name, email) => {
   execute(`git config --global user.name "${name}"`)
@@ -38,10 +39,17 @@ export const setGitLogAlias = (scriptPath) => {
 
 const copyGitCollabPostCommit = (gitHooksPath) => {
   const source = path.join(GIT_COLLAB_PATH, 'post-commit')
-  const destination = path.join(gitHooksPath, 'post-commit.git-collab')
+  const gitCollabDir = path.join(gitHooksPath, 'git-collab')
 
+  fs.mkdirSync(gitCollabDir, { recursive: true })
+
+  const destination = path.join(gitCollabDir, 'post-commit')
   const postCommitContents = fs.readFileSync(source, 'utf-8')
   fs.writeFileSync(destination, postCommitContents, { encoding: 'utf-8', mode: 0o755 })
+
+  if (!gitHooksPath.match(/\.git\/hooks$/)) {
+    fs.writeFileSync(path.join(gitHooksPath, 'git-collab', '.gitignore'), '*', { encoding: 'utf-8' })
+  }
 }
 
 const mergePostCommitScripts = (postCommitFile, gitHooksPath) => {
@@ -49,6 +57,13 @@ const mergePostCommitScripts = (postCommitFile, gitHooksPath) => {
   if (postCommitScript.includes(GIT_SWITCH_POST_COMMIT_BASE)) {
     postCommitScript = postCommitScript.replace('git-switch', 'git-collab')
     fs.unlinkSync(path.join(gitHooksPath, 'post-commit.git-switch'))
+  }
+  if (postCommitScript.includes('post-commit.git-collab')) {
+    fs.unlinkSync(path.join(gitHooksPath, 'post-commit.git-collab'))
+  }
+
+  if (postCommitScript.includes(POST_COMMIT_BASE_OLD)) {
+    postCommitScript = postCommitScript.replace(POST_COMMIT_BASE_OLD, POST_COMMIT_BASE)
   }
 
   if (!postCommitScript.includes(POST_COMMIT_BASE)) {
@@ -75,7 +90,7 @@ const addPostCommitFiles = (destination) => {
 
 const getSubmodulesForRepo = (repoPath) => {
   const submodulesStatus = execute('git submodule status', { cwd: repoPath })
-  const statuses = (submodulesStatus && submodulesStatus.trim().split('\n')) || []
+  const statuses = submodulesStatus?.toString().trim().split('\n') ?? []
 
   return statuses.map((s) => s.trim().split(' ')[1])
 }
@@ -95,26 +110,45 @@ const addPostCommitFilesToSubModules = (repoPath) => {
 
 export const initRepo = (repoPath) => {
   if (!fs.existsSync(repoPath)) {
-    logger.error('The specified path does not exist')
-    return false
+    logger.error('Path not found:', repoPath)
+    return { isValid: false }
   }
   if (!fs.existsSync(path.join(repoPath, '.git'))) {
-    logger.error('The specified path does not contain a ".git" directory')
-    return false
+    logger.error('Path not a git repository:', repoPath)
+    return { isValid: false }
   }
 
-  logger.info(`Writing post-commit hook to repo "${repoPath}"`)
+  logger.info('Writing post-commit hook to repository:', repoPath)
 
-  addPostCommitFiles(path.join(repoPath, '.git', 'hooks'))
+  let hooksPath = path.join(repoPath, '.git', 'hooks')
+  try {
+    const localHooksPath = execute('git config --local core.hooksPath', { cwd: repoPath })
+    hooksPath = localHooksPath
+      ? path.join(repoPath, localHooksPath.toString().trim())
+      : hooksPath
+
+    // Do not write to the managed husky directory
+    if (hooksPath.match(/\.husky\/_$/)) {
+      hooksPath = hooksPath.replace(/\.husky\/_$/, '.husky')
+    }
+  } catch (e) {
+    // no-op
+  }
+
+  addPostCommitFiles(hooksPath)
   addPostCommitFilesToSubModules(repoPath)
 
-  return true
+  return { hooksPath, isValid: true }
 }
 
 const removeGitCollabPostCommitScript = (gitHooksPath) => {
-  const postCommitGitCollabFile = path.join(gitHooksPath, 'post-commit.git-collab')
-  if (fs.existsSync(postCommitGitCollabFile)) {
-    fs.unlinkSync(postCommitGitCollabFile)
+  const postCommitGitCollabDir = path.join(gitHooksPath, 'git-collab')
+  if (fs.existsSync(postCommitGitCollabDir)) {
+    fs.rmdirSync(postCommitGitCollabDir, { recursive: true, force: true })
+  }
+  const oldPostCommitGitCollabFile = path.join(gitHooksPath, 'post-commit.git-collab')
+  if (fs.existsSync(oldPostCommitGitCollabFile)) {
+    fs.unlinkSync(oldPostCommitGitCollabFile)
   }
 }
 
@@ -122,18 +156,20 @@ const removePostCommitScript = (gitHooksPath) => {
   const postCommitFile = path.join(gitHooksPath, 'post-commit')
   if (fs.existsSync(postCommitFile)) {
     let postCommitScript = fs.readFileSync(postCommitFile, 'utf-8')
-    if (postCommitScript === POST_COMMIT_BASE) {
+    if (postCommitScript === POST_COMMIT_BASE || postCommitScript === POST_COMMIT_BASE_OLD) {
       fs.unlinkSync(postCommitFile)
     } else {
-      postCommitScript = postCommitScript.replace(POST_COMMIT_BASE, '#!/bin/bash')
+      postCommitScript = postCommitScript
+        .replace(POST_COMMIT_BASE, '#!/usr/bin/env sh')
+        .replace(POST_COMMIT_BASE, '#!/usr/bin/env sh')
       fs.writeFileSync(postCommitFile, postCommitScript, { encoding: 'utf-8', mode: 0o755 })
     }
   }
 }
 
 const removePostCommitFiles = (target) => {
-  removeGitCollabPostCommitScript(target)
   removePostCommitScript(target)
+  removeGitCollabPostCommitScript(target)
 }
 
 const removePostCommitFilesFromSubModules = (target) => {
@@ -144,7 +180,7 @@ const removePostCommitFilesFromSubModules = (target) => {
   }
 }
 
-export const removeRepo = (repoPath) => {
-  removePostCommitFiles(path.join(repoPath, '.git', 'hooks'))
+export const removeRepo = (repoPath, hooksPath) => {
+  removePostCommitFiles(hooksPath)
   removePostCommitFilesFromSubModules(path.join(repoPath, '.git', 'modules'))
 }

--- a/src/common/services/repo.js
+++ b/src/common/services/repo.js
@@ -30,11 +30,11 @@ export const add = (path) => {
     repos = repos.filter((r) => r !== existingRepo)
   }
 
-  const isValid = gitService.initRepo(path)
+  const { hooksPath, isValid } = gitService.initRepo(path)
 
   return persist([
     ...repos,
-    { name, path, isValid }
+    { name, path, hooksPath: hooksPath ?? '', isValid }
   ])
 }
 
@@ -48,11 +48,16 @@ export const remove = (path) => {
     return repos
   }
 
-  if (repos[foundIndex].isValid) {
-    gitService.removeRepo(path)
+  const foundRepo = repos[foundIndex]
+  if (foundRepo.isValid) {
+    gitService.removeRepo(path, foundRepo.hooksPath)
   }
 
   repos.splice(foundIndex, 1)
 
+  return persist(repos)
+}
+
+export const update = (repos) => {
   return persist(repos)
 }

--- a/src/common/utils/__specs__/logger.spec.js
+++ b/src/common/utils/__specs__/logger.spec.js
@@ -1,11 +1,9 @@
-/* eslint-disable no-console */
-
 import { logger as subject } from '../'
 import sandbox from '../../../../test/sandbox'
 
 describe('utils/logger', () => {
   beforeEach(() => {
-    sandbox.spy(console, 'log')
+    sandbox.spy(console, 'info')
     sandbox.spy(console, 'error')
   })
   afterEach(() => {
@@ -20,7 +18,7 @@ describe('utils/logger', () => {
 
     it('logs info to console', () => {
       subject.info('foo')
-      expect(console.log).to.have.been.called
+      expect(console.info).to.have.been.called
     })
 
     it('logs errors to console', () => {
@@ -36,7 +34,7 @@ describe('utils/logger', () => {
 
     it('does not log info to console', () => {
       subject.info('foo')
-      expect(console.log).to.not.be.called
+      expect(console.info).to.not.be.called
     })
 
     it('logs errors to console', () => {
@@ -45,5 +43,3 @@ describe('utils/logger', () => {
     })
   })
 })
-
-/* eslint-enable no-console */

--- a/src/common/utils/logger.js
+++ b/src/common/utils/logger.js
@@ -1,12 +1,8 @@
-/* eslint-disable no-console */
-
 const consoleLog = (func, args) => {
   if (!global.logToConsoleDisabled) {
     func.apply(console, args)
   }
 }
 
-export const info = (...args) => consoleLog(console.log, args)
+export const info = (...args) => consoleLog(console.info, args)
 export const error = (...args) => consoleLog(console.error, args)
-
-/* eslint-enable no-console */


### PR DESCRIPTION
As of husky 7.x, there was a significant change in how husky hooks work, which again breaks `git-collab` adding a post-commit hook. This fixes that by making `git-collab` aware of the local `core.hooksPath` on the repo and saving/moving the post-commit hooks accordingly.

Some other maintenance things are also contained in individual commits:
- Fixing node version errors
- Fixing lint and console logging
- Updating github action versions
- Fix windows packing with latest ubuntu action runners